### PR TITLE
feat: Add modals, about section, and past shows archive

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,18 @@
                 <!-- Shows will be dynamically inserted here by script.js -->
             </ul>
         </section>
+
+        <section id="about">
+            <h2>About The Venue</h2>
+            <p id="about-content"></p>
+        </section>
+
+        <section id="past-shows">
+            <h2>Past Shows Archive</h2>
+            <ul id="past-shows-list">
+                <!-- Past shows will be dynamically inserted here -->
+            </ul>
+        </section>
     </main>
 
     <footer id="info-contact">
@@ -34,6 +46,17 @@
             <a href="#" target="_blank">Facebook</a>
         </div>
     </footer>
+
+    <!-- Modal Structure -->
+    <div id="show-modal" class="modal hidden">
+        <div class="modal-overlay"></div>
+        <div class="modal-content">
+            <button class="modal-close-btn">&times;</button>
+            <div id="modal-body-content">
+                <!-- Dynamic content will be injected here -->
+            </div>
+        </div>
+    </div>
 
     <script src="script.js"></script>
 </body>

--- a/mock-data.json
+++ b/mock-data.json
@@ -1,0 +1,50 @@
+{
+  "about": "In het oude gebouw van De Boerenbond in Vertrijk huist sinds de zomer van 2018 MAGAZIJN DE SNOEK vzw. MAGAZIJN DE SNOEK is creatief, sociaal en ecologisch geëngageerd en biedt een platform aan talent en burgerinitiatief uit het Hageland.",
+  "releases": [
+    {
+      "name": "Openingsfeest // 2025-07-05",
+      "body": "### Details\n\n*   **Time:** 17:00 - 01:00\n*   **Acts:** DJ Collina, Je Suis m'Appelle, Alpacas Collective, DJ Zuri\n\n[Tickets](https://magazijndesnoek.be/kalender)",
+      "html_url": "https://magazijndesnoek.be/kalender"
+    },
+    {
+      "name": "Pieter-Jan De Smet // 2025-07-26",
+      "body": "### Details\n\n*   **Time:** 20:30\n\nAn intimate solo performance by the legendary Pieter-Jan De Smet.\n\n[Tickets](https://magazijndesnoek.be/kalender)",
+      "html_url": "https://magazijndesnoek.be/kalender"
+    },
+    {
+      "name": "The Swimm // 2025-08-09",
+      "body": "### Details\n\n*   **Time:** 20:30\n\nEnjoy the atmospheric sounds of The Swimm.\n\n[Tickets](https://magazijndesnoek.be/kalender)",
+      "html_url": "https://magazijndesnoek.be/kalender"
+    },
+    {
+      "name": "Poppentheater 'Roestwolken' // 2025-08-16",
+      "body": "### Details\n\n*   **Time:** 20:00\n\nA magical puppet show for all ages.\n\n[Tickets](https://magazijndesnoek.be/kalender)",
+      "html_url": "https://magazijndesnoek.be/kalender"
+    },
+    {
+      "name": "Tree of Smoke // 2025-08-16",
+      "body": "### Details\n\n*   **Time:** 21:30\n\nPost-rock soundscapes to close out the evening.\n\n[Tickets](https://magazijndesnoek.be/kalender)",
+      "html_url": "https://magazijndesnoek.be/kalender"
+    },
+    {
+      "name": "The Irish Rheumatics // 2025-08-23",
+      "body": "### Details\n\n*   **Time:** 20:00\n\nLively Irish folk music.\n\n[Tickets](https://magazijndesnoek.be/kalender)",
+      "html_url": "https://magazijndesnoek.be/kalender"
+    },
+    {
+      "name": "Son del corazón // 2025-08-23",
+      "body": "### Details\n\n*   **Time:** 21:00\n\nAuthentic Cuban sounds.\n\n[Tickets](https://magazijndesnoek.be/kalender)",
+      "html_url": "https://magazijndesnoek.be/kalender"
+    },
+    {
+      "name": "Dadawaves // 2025-08-30",
+      "body": "### Details\n\n*   **Time:** 21:00\n\nExperimental electronic music.\n\n[Tickets](https://magazijndesnoek.be/kalender)",
+      "html_url": "https://magazijndesnoek.be/kalender"
+    },
+    {
+      "name": "Closing Night Party // 2024-09-15",
+      "body": "### Details\n\n*   **Time:** 22:00\n\nA past event to test the archive functionality.\n\n[Tickets](#)",
+      "html_url": "#"
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -1,23 +1,55 @@
 // --- CONFIGURATION ---
-// IMPORTANT: Replace with your public GitHub repository path
-// The repository must have releases with titles formatted as: "Artist Name // YYYY-MM-DD"
-const GITHUB_REPO = 'tech-creative-cat/example-assets';
+// The app now loads data from mock-data.json by default.
+// To switch back to GitHub releases, comment out the mock data fetch
+// and uncomment the GITHUB_REPO and the original fetch call.
+// const GITHUB_REPO = 'your-username/your-repo-name';
 
 // --- DOM ELEMENTS ---
 const showsList = document.getElementById('shows-list');
 const upcomingShowsSection = document.getElementById('upcoming-shows');
+const pastShowsList = document.getElementById('past-shows-list');
+const modal = document.getElementById('show-modal');
+const modalContent = document.getElementById('modal-body-content');
+const modalCloseBtn = document.querySelector('.modal-close-btn');
+const modalOverlay = document.querySelector('.modal-overlay');
+const aboutContent = document.getElementById('about-content');
 
 // --- HELPER FUNCTIONS ---
 
 /**
- * A simple Markdown parser. For this project, it just handles links.
+ * A simple Markdown parser. Handles H3, lists, and links.
  * @param {string} text - The Markdown text.
  * @returns {string} - The HTML representation.
  */
 function parseMarkdown(text) {
+    let html = text;
+    // Convert ### headers to <h3>
+    html = html.replace(/^### (.*$)/gim, '<h3>$1</h3>');
+    // Convert * list items to <li>
+    html = html.replace(/^\* (.*$)/gim, '<li>$1</li>');
+    // Wrap <li>s in a <ul>
+    html = html.replace(/<li>.*<\/li>/gs, '<ul>$&</ul>');
     // Convert [link text](URL) to <a href="URL">link text</a>
-    const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
-    return text.replace(linkRegex, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    return html;
+}
+
+/**
+ * Opens the modal and populates it with show details.
+ * @param {object} show - The show object.
+ */
+function openModal(show) {
+    if (!modal || !modalContent) return;
+    modalContent.innerHTML = parseMarkdown(show.body);
+    modal.classList.remove('hidden');
+}
+
+/**
+ * Closes the modal.
+ */
+function closeModal() {
+    if (!modal) return;
+    modal.classList.add('hidden');
 }
 
 /**
@@ -41,58 +73,68 @@ async function loadShows() {
     showsList.innerHTML = '<p>Loading shows...</p>';
 
     try {
-        const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases`);
+        // Fetch from local mock data file
+        const response = await fetch('mock-data.json');
 
         if (!response.ok) {
-            throw new Error(`GitHub API error: ${response.status}`);
+            throw new Error(`Network response was not ok: ${response.statusText}`);
         }
 
-        const releases = await response.json();
+        const data = await response.json();
+        aboutContent.textContent = data.about; // Populate about section
+        const releases = data.releases; // Extract the releases array
 
         const today = new Date();
         today.setHours(0, 0, 0, 0); // Set to start of today for accurate comparison
 
-        const upcomingShows = releases
-            .map(release => {
-                const parts = release.name.split('//');
-                if (parts.length !== 2) return null;
+        const allShows = releases.map(release => {
+            const parts = release.name.split('//');
+            if (parts.length !== 2) return null;
 
-                const artist = parts[0].trim();
-                const dateStr = parts[1].trim();
-                const eventDate = new Date(dateStr);
+            const artist = parts[0].trim();
+            const dateStr = parts[1].trim();
+            const eventDate = new Date(dateStr);
 
-                // Adjust for timezone offset to treat date as UTC
-                const timezoneOffset = eventDate.getTimezoneOffset() * 60000;
-                const utcDate = new Date(eventDate.getTime() + timezoneOffset);
+            const timezoneOffset = eventDate.getTimezoneOffset() * 60000;
+            const utcDate = new Date(eventDate.getTime() + timezoneOffset);
 
+            return {
+                artist: artist,
+                date: utcDate,
+                details: release.body || 'No additional details provided.',
+                url: release.html_url
+            };
+        }).filter(show => show); // Filter out any nulls from parsing errors
 
-                return {
-                    artist: artist,
-                    date: utcDate,
-                    details: release.body || 'No additional details provided.',
-                    url: release.html_url
-                };
-            })
-            .filter(show => show && show.date >= today)
+        const upcomingShows = allShows
+            .filter(show => show.date >= today)
             .sort((a, b) => a.date - b.date);
 
-        renderShows(upcomingShows);
+        const pastShows = allShows
+            .filter(show => show.date < today)
+            .sort((a, b) => b.date - a.date); // Sort past shows newest first
+
+        renderShows(upcomingShows, showsList, 'No upcoming shows at the moment. Check back soon!');
+        renderShows(pastShows, pastShowsList, 'No past shows in the archive yet.');
 
     } catch (error) {
         console.error('Failed to load shows:', error);
-        showsList.innerHTML = '<p>Could not load shows. Please check the repository configuration.</p>';
+        showsList.innerHTML = '<p>Could not load shows. Please check the configuration.</p>';
     }
 }
 
 /**
- * Renders the list of shows into the DOM.
+ * Renders a list of shows into a target DOM element.
  * @param {Array} shows - An array of show objects.
+ * @param {HTMLElement} targetElement - The <ul> element to render into.
+ * @param {string} emptyMessage - Message to display if shows array is empty.
  */
-function renderShows(shows) {
-    showsList.innerHTML = ''; // Clear loading message
+function renderShows(shows, targetElement, emptyMessage) {
+    if (!targetElement) return;
+    targetElement.innerHTML = ''; // Clear loading/previous message
 
     if (shows.length === 0) {
-        showsList.innerHTML = '<p>No upcoming shows at the moment. Check back soon!</p>';
+        targetElement.innerHTML = `<p>${emptyMessage}</p>`;
         return;
     }
 
@@ -108,19 +150,20 @@ function renderShows(shows) {
         artistEl.className = 'show-artist';
         artistEl.textContent = show.artist;
 
-        const infoBtn = document.createElement('a');
+        const infoBtn = document.createElement('button');
         infoBtn.className = 'show-info-btn';
-        infoBtn.href = show.url;
         infoBtn.textContent = 'More Info';
-        infoBtn.target = '_blank'; // Open in new tab
+        infoBtn.addEventListener('click', () => openModal(show));
 
         listItem.appendChild(dateEl);
         listItem.appendChild(artistEl);
         listItem.appendChild(infoBtn);
 
-        showsList.appendChild(listItem);
+        targetElement.appendChild(listItem); // Correctly append to the target element
     });
 }
 
-// --- INITIALIZATION ---
+// --- INITIALIZATION & EVENT LISTENERS ---
 document.addEventListener('DOMContentLoaded', loadShows);
+modalCloseBtn.addEventListener('click', closeModal);
+modalOverlay.addEventListener('click', closeModal);

--- a/style.css
+++ b/style.css
@@ -129,6 +129,47 @@ body {
     color: #111;
 }
 
+/* --- ABOUT SECTION --- */
+#about {
+    padding: 60px 20px;
+    text-align: center;
+    background-color: #050505;
+    border-top: 1px solid #333;
+    border-bottom: 1px solid #333;
+}
+
+#about h2 {
+    font-size: 2.5rem;
+    margin-bottom: 20px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+#about p {
+    max-width: 700px;
+    margin: 0 auto;
+    font-size: 1.1rem;
+    line-height: 1.8;
+    color: #ccc;
+}
+
+/* --- PAST SHOWS --- */
+#past-shows {
+    padding: 50px 20px;
+}
+
+#past-shows h2 {
+    font-size: 2.5rem;
+    text-align: center;
+    margin-bottom: 40px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+#past-shows .show-item {
+    opacity: 0.7;
+}
+
 /* --- FOOTER --- */
 #info-contact {
     text-align: center;
@@ -173,4 +214,85 @@ body {
     .show-date, .show-artist {
         margin-bottom: 10px;
     }
+}
+
+/* --- MODAL STYLES --- */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.modal:not(.hidden) {
+    visibility: visible;
+    opacity: 1;
+}
+
+.modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    cursor: pointer;
+}
+
+.modal-content {
+    position: relative;
+    background-color: #1a1a1a;
+    padding: 40px;
+    border-radius: 5px;
+    max-width: 600px;
+    width: 90%;
+    z-index: 1001;
+    transform: translateY(-20px);
+    transition: transform 0.3s ease;
+}
+
+.modal:not(.hidden) .modal-content {
+    transform: translateY(0);
+}
+
+.modal-close-btn {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    background: none;
+    border: none;
+    color: #aaa;
+    font-size: 2rem;
+    cursor: pointer;
+    transition: color 0.3s ease;
+}
+
+.modal-close-btn:hover {
+    color: #fff;
+}
+
+#modal-body-content h3 {
+    margin-bottom: 15px;
+    font-size: 1.8rem;
+}
+
+#modal-body-content p, #modal-body-content ul {
+    margin-bottom: 15px;
+}
+
+#modal-body-content a {
+    color: #4a90e2;
+    text-decoration: none;
+}
+
+#modal-body-content a:hover {
+    text-decoration: underline;
 }


### PR DESCRIPTION
This commit significantly enhances the concert venue website by adding several new features and switching to a static data source for robust development and deployment on GitHub Pages.

Key changes include:
- **Static Data Source:** The site now loads all concert and venue information from a local `mock-data.json` file. This approach was chosen due to browser CORS restrictions preventing live scraping on a static host.
- **Detailed Show Modals:** Clicking the "More Info" button on a show now opens an on-page modal with detailed information, rather than linking to an external page.
- **About Us Section:** A new section has been added to the homepage to display information about the venue.
- **Past Shows Archive:** The application now separates events into upcoming and past shows, displaying the latter in a new "Past Shows Archive" section to provide a sense of history.
- **Bug Fix:** Corrected a rendering bug where past shows were not being appended to the correct list.